### PR TITLE
Use mpfr module from the runtime

### DIFF
--- a/org.kde.kalk.json
+++ b/org.kde.kalk.json
@@ -20,21 +20,6 @@
         "*.a"
     ],
     "modules": [
-        {
-            "name": "mpfr",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz",
-                    "sha256": "b67ba0383ef7e8a8563734e2e889ef5ec3c3b898a01d00fa0a6869ad81c6ce01",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 2019,
-                        "url-template": "https://ftp.gnu.org/gnu/mpfr/mpfr-$version.tar.xz"
-                    }
-                }
-            ]
-        },
         "shared-modules/intltool/intltool-0.51.json",
         {
             "name": "libqalculate",


### PR DESCRIPTION
KDE runtime version 6.10 (based on the Freedesktop runtime version **25.08**) appears to provide the **mpfr** module. 

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration. 

**Related manifest file:** 

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/components/mpfr.bst

Fixes: https://github.com/flathub/org.kde.kalk/issues/103